### PR TITLE
Found a syntax error with an extra close parenthesis.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.register = function(plugin, options, next) {
     fs
     .readdirSync(path.resolve(__dirname, '../../models'))
     .filter(function(file) {
-        return (file.indexOf('.') !== 0) && (file !== 'index.js'));
+        return (file.indexOf('.') !== 0) && (file !== 'index.js');
     })
     .forEach(function(file) {
         var model = sequelize.import(path.join(path.resolve(__dirname, '../../models'), file));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-sequelized",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A plugin for using sequlize with the hapi.js web framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
While looking at the available plugins for hapi and sequelizejs I came across this one through the http://hapijs.com site.

When trying to load the plugin in a hapi 8 environment I had an exception come up:

```
/Users/ri/scratch/hapi_eight_server/node_modules/hapi-sequelized/index.js:18
        return (file.indexOf('.') !== 0) && (file !== 'index.js'));
                                                                 ^
```

This quickly resolves that issue. I don't have the time this evening to finish testing. 

As a part of this I also bumped the version.

-r
