### PR TITLE
Abstract database setup out of the plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,14 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var Sequelize = require('sequelize');
 
-
-/**
- * Register sequelize as a Hapi plugin
- * @param plugin
- * @param options
- * @param next
- */
-exports.register = function(plugin, options, next) {
+exports.setupDB = function(options, callback) {
 
     var dir = [];
     var logging = process.env.NODE_ENV === 'production' ? false : console.log;
@@ -64,13 +57,28 @@ exports.register = function(plugin, options, next) {
             db.sequelize = sequelize;
             db.Sequelize = Sequelize;
 
-            plugin.expose('db', db);
-
-            return next();
+            return callback(null, db);
         })
-        .catch(function(err) {
+        .catch(callback);
+}
+
+/**
+ * Register sequelize as a Hapi plugin
+ * @param plugin
+ * @param options
+ * @param next
+ */
+exports.register = function(plugin, options, next) {
+
+    exports.setupDB(options, function(err, db) {
+
+        if (err) {
             return next(err);
-        });
+        }
+
+        plugin.expose('db', db);
+        return next();
+    })
 };
 
 exports.register.attributes = {

--- a/test/index.js
+++ b/test/index.js
@@ -169,4 +169,20 @@ describe('Hapi-Sequelized', function () {
 
         });
 
+    it('should provide the db object via setupDB method',
+        function (done) {
+
+            var hapiSequelized = require('..');
+
+            hapiSequelized.setupDB(options, function(err, db) {
+
+                // no errors
+                expect(err).to.not.exist;
+
+                //instance of Sequelize should be registered
+                expect(db.sequelize).to.be.an.instanceOf(Sequelize);
+                done();
+            })
+        });
+
 });


### PR DESCRIPTION
Allows models and DB configuration to be used by seeds and migrations.

The plugin works just like normal, but if you don't want to load a Hapi server for migrations and seed data creation, you can now do something this: 

```js
var options = require('./some-config.js');
require('hapi-sequelized').setupDB(options, function(err, db) {
  // use db and any defined models
});
```