### PR TITLE
give user freedom to configure logging options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,6 @@ var Sequelize = require('sequelize');
  */
 exports.register = function(plugin, options, next) {
 
-    // sequelize query output disabled in production
-    var logging = process.env.NODE_ENV === 'production' ? false : console.log;
-
     // default directory for models
     options.models = options.models || 'models/**/*.js';
 
@@ -22,7 +19,7 @@ exports.register = function(plugin, options, next) {
         host: options.host || 'localhost',
         dialect: options.dialect || 'mysql',
         port: options.port || 3306,
-        logging: logging
+        logging: options.logging === false ? false : options.logging || console.log
     };
 
     // apply top level plugin options to a full sequelize options object


### PR DESCRIPTION
so that user can use custom logging function other than `console.log` or explicitly disable it.