### PR TITLE
Passing in URI for Database Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ server.register(
 );
 ```
 
+You can also pass in a [database connection URI][1] in the events that your
+database connection is extracted from the codebase, like on Heroku:
+
+```javascript
+server.register(
+    [
+        {
+            register: require('hapi-sequelized'),
+            options: {
+                uri: process.env.DATABASE_URI,
+                models: 'models/**/*.js',
+                sequelize: {
+                    define: {
+                        underscoredAll: true
+                    }
+                }
+            }
+        },
+    ], function(err) {
+        if (err) {
+            console.error('failed to load plugin');
+        }
+    }
+);
+```
+
 ### Available Options
 
 ```javascript
@@ -51,6 +77,7 @@ options: {
     dialect: 'mysql',   // database type
     host: 'localhost',  // db host
     port: 8889,         // database port #
+    uri: 'postgres://user:pass@example.com:5432/dbname' // database URI
     models: ['models/**/*.js', 'other/models/*.js'],   // glob or an array of globs to directories containing your sequelize models
     logging: false      // sql query logging
     sequelize: {       // Options object passed to the Sequelize constructor http://docs.sequelizejs.com/en/latest/api/sequelize/#new-sequelizedatabase-usernamenull-passwordnull-options
@@ -151,3 +178,5 @@ Also make sure to take a look at the changelog if you're upgrading from a pre 3+
 version. There are several breaking changes that will need to be addressed.
 
 https://github.com/sequelize/sequelize/blob/master/changelog.md
+
+[1]: http://sequelize.readthedocs.org/en/latest/api/sequelize/#new-sequelizeuri-options

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,12 +19,19 @@ exports.register = function(plugin, options, next) {
         host: options.host || 'localhost',
         dialect: options.dialect || 'mysql',
         port: options.port || 3306,
-        logging: options.logging === false ? false : options.logging || console.log
+        logging: options.logging === false ? false : options.logging || console.log,
+        uri: options.uri === false ? false : options.uri
     };
 
     // apply top level plugin options to a full sequelize options object
     var sequelizeOptions = Hoek.applyToDefaults(defaultOptions, options.sequelize || {});
-    var sequelize = new Sequelize(options.database, options.user, options.pass, sequelizeOptions);
+    var sequelize = undefined;
+    if (!options.uri) {
+      delete options.uri;
+      sequelize = new Sequelize(options.database, options.user, options.pass, sequelizeOptions);
+    } else {
+      sequelize = new Sequelize(options.uri, sequelizeOptions);
+    }
 
     // test the database connection
     sequelize.authenticate()

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ exports.register = function(plugin, options, next) {
 
     // apply top level plugin options to a full sequelize options object
     var sequelizeOptions = Hoek.applyToDefaults(defaultOptions, options.sequelize || {});
-    var sequelize = undefined;
+    var sequelize;
     if (!options.uri) {
       delete options.uri;
       sequelize = new Sequelize(options.database, options.user, options.pass, sequelizeOptions);

--- a/test/index.js
+++ b/test/index.js
@@ -163,4 +163,34 @@ describe('hapi-sequelized', function() {
                 done();
             });
         });
+
+    it('should connect to a database using the URI format',
+       function(done) {
+            options.uri = options.dialect + '://' + options.user + ':' + options.pass + '@' + options.host + ':' + options.port + '/' + options.database
+            delete options.host;
+            delete options.port;
+            delete options.dialect;
+            delete options.user;
+            delete options.pass;
+            delete options.database;
+
+            var register = {
+               register: require('..'),
+               options: options
+            };
+
+           server.register([register], function() {
+                var models = server.plugins['hapi-sequelized'].db.sequelize.models;
+
+                // check if all models were imported
+                expect(models.User).to.exist();
+                expect(models.Product).to.exist();
+                expect(models.Category).to.exist();
+                expect(models.BlogRoll).to.exist();
+                expect(models.Blog).to.exist();
+                expect(models.Post).to.exist();
+
+                done();
+           });
+       });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -16,26 +16,29 @@ describe('hapi-sequelized', function() {
     var server;
 
     // Options to test
-    var options = {
-        host: '127.0.0.1',
-        database: 'testing',
-        user: 'root',
-        pass: '',
-        port: 3306,
-        dialect: 'mysql',
-        models: ['test/models/**/*.js', 'test/other-models/**/*.js'],
-        sequelize: {
-            define: {
-                timestamps: false
-            }
-        }
-    };
+    var options = {};
 
     // Setup Hapi server to register the plugin
     beforeEach(function(done) {
         server = new Hapi.Server();
         server.connection();
         done();
+
+        options = {
+            host: '127.0.0.1',
+            database: 'testing',
+            user: 'root',
+            pass: '',
+            port: 3306,
+            dialect: 'mysql',
+            models: ['test/models/**/*.js', 'test/other-models/**/*.js'],
+            sequelize: {
+                define: {
+                    timestamps: false
+                }
+            }
+        };
+
     });
 
     it('should register the plugin',


### PR DESCRIPTION
The plugin allows for the object construction of the database parameters
but does not allow for the [URI approach][1]. This PR does this and adds a
test for it as well.

[1]: http://sequelize.readthedocs.org/en/latest/api/sequelize/#new-sequelizeuri-options